### PR TITLE
lms: remove uint_fast8_t in buffers

### DIFF
--- a/lms.c
+++ b/lms.c
@@ -294,7 +294,7 @@ void recover_lmots_public_key(lms_public_key *pk, lms_signature *sig,
 
 	sha256_ctx ctx;
 	uint16_t D_public = 0x8080;
-	uint_fast8_t tmp_concat[22] = { 0 };
+	uint8_t tmp_concat[22] = { 0 };
 	sha256_init(&ctx);
 	//sha2_256_init(&ctx, pk_tc);
 
@@ -388,7 +388,7 @@ void recover_lmots_public_key_f(unsigned char *pk, unsigned char *sig,
 
 	sha256_ctx ctx;
 	uint16_t D_public = 0x8080;
-	uint_fast8_t tmp_concat[22] = { 0 };
+	uint8_t tmp_concat[22] = { 0 };
 	sha256_init(&ctx);
 	//sha2_256_init(&ctx, pk_tc);
 

--- a/lms_ots.c
+++ b/lms_ots.c
@@ -19,14 +19,14 @@ void gen_lmots_public_key(unsigned char *sk, unsigned char *pk) {
 	ull_to_bytes(sk, LMOTS_ALG_TYPE, 4);
 	ull_to_bytes(pk, LMOTS_ALG_TYPE, 4);
 	uint16_t D_public = 0x8080;
-	uint_fast8_t tmp[32] = { 0 };
+	uint8_t tmp[32] = { 0 };
 	sha256_ctx ctx;
 	sha256_init(&ctx);
 	memcpy(tmp, sk + 4, 20);
 	memcpy(tmp + 20, &D_public, 2);
 	sha256_update(&ctx, tmp, 22);
 
-	uint_fast8_t tmp_concatenated[55] = { 0 };
+	uint8_t tmp_concatenated[55] = { 0 };
 	memset(tmp, 0, 32);
 
 	for (int i = 0; i < P; i++) {
@@ -144,7 +144,7 @@ int lms_ots_verify(unsigned char *message, size_t input_size, unsigned char *pk,
 
 	sha256_ctx ctx;
 	uint16_t D_public = 0x8080;
-	uint_fast8_t tmp_concat[22] = { 0 };
+	uint8_t tmp_concat[22] = { 0 };
 	sha256_init(&ctx);
 
 	memcpy(tmp_concat, pk + 36, 20);

--- a/lms_utils.c
+++ b/lms_utils.c
@@ -18,8 +18,8 @@ void deserialize_lmsots_signature(unsigned char *from, lmots_signature *to) {
 	memcpy(to->y, from + 36, P * 32);
 }
 
-void concat_hash_value(const uint_fast8_t *S, const uint_fast8_t *tmp,
-		uint16_t i, uint8_t j, uint_fast8_t *result) {
+void concat_hash_value(const uint8_t *S, const uint8_t *tmp,
+		uint16_t i, uint8_t j, uint8_t *result) {
 	memcpy(result, S, 20);
 	ull_to_bytes(result + 20, i, 2);
 	memcpy(result + 22, &j, 1);

--- a/lms_utils.h
+++ b/lms_utils.h
@@ -22,8 +22,8 @@
 /**
  * Concatenation of S, tmp, i in big endian, and j.
  */
-void concat_hash_value(const uint_fast8_t *S, const uint_fast8_t *tmp,
-		uint16_t i, uint8_t j, uint_fast8_t *result);
+void concat_hash_value(const uint8_t *S, const uint8_t *tmp,
+		uint16_t i, uint8_t j, uint8_t *result);
 
 /**
  * Function to get the ith bit from Q as define in https://datatracker.ietf.org/doc/html/rfc8554#section-3.1.3


### PR DESCRIPTION
`uint_fast8_t` depends on the compiler and target platform for it's size
and can be between 1 and 8 bytes in size. Using this for buffers
together with `memcpy` or memcpy-like structures is not always safe, for
example this results in a different extracted key on a Cortex-m4 with
gcc

I spotted this while testing on Cortex-M4 and debugging why results are different between x86 and armv7.